### PR TITLE
Category delete button

### DIFF
--- a/src/components/categories/CategoryList.css
+++ b/src/components/categories/CategoryList.css
@@ -21,3 +21,15 @@
     font-size: 35px;
     padding: 20px 90px;
 }
+
+.category__button {
+    height: 2rem;
+    width: 4rem;
+    padding: 0.2rem 0.5rem;
+    margin: 0.2rem;
+    border-radius: 1rem;
+}
+
+.category__buttons {
+    margin: 1rem;
+}

--- a/src/components/categories/CategoryList.js
+++ b/src/components/categories/CategoryList.js
@@ -22,7 +22,7 @@ export const CategoryList = () => {
         // whenever confirmed by clicking OK/Cancel window.confirm() returns boolean 
         let text = 'Are you sure you want to delete this category?'
         window.confirm(text)
-            ? deleteCategory(category.id).then(() => navigate("/categories"))
+            ? deleteCategory(category.id).then(() => {window.location.reload()})
             : <></>
     }
 
@@ -30,7 +30,8 @@ export const CategoryList = () => {
         {categories.map(category => {
             return <div key={`category--${category.id}`} className="category">
                 <h3 className="category_label">{category.label}</h3>
-        <button className="category__button button is-small is-responsive is-danger" onClick={(evt) => categoryDelete(evt, category).then(() => {window.location.reload()})}>Delete</button>     
+        <button className="category__button button is-small is-responsive is-danger" 
+        onClick={(evt) => categoryDelete(evt, category)}>Delete</button>     
                 <div>
                 </div>
             </div>

--- a/src/components/categories/CategoryList.js
+++ b/src/components/categories/CategoryList.js
@@ -1,9 +1,14 @@
 import { useEffect, useState } from "react"
-import { getCategories } from "../../managers/CategoryManager"
+import { Link, useNavigate } from "react-router-dom"
+import { getCategories, deleteCategory } from "../../managers/CategoryManager"
 import './CategoryList.css'
 
 export const CategoryList = () => {
     const [categories, setCategories] = useState([])
+    const navigate = useNavigate()
+
+    const localForumUser = localStorage.getItem("forum_user")
+    const forumUserObject = JSON.parse(localForumUser)
 
     useEffect (
         () => {
@@ -13,10 +18,19 @@ export const CategoryList = () => {
         []
     )
 
+    const categoryDelete = (evt, category) => {
+        // whenever confirmed by clicking OK/Cancel window.confirm() returns boolean 
+        let text = 'Are you sure you want to delete this category?'
+        window.confirm(text)
+            ? deleteCategory(category.id).then(() => navigate("/categories"))
+            : <></>
+    }
+
     return <section> <div className="category_title">Category List</div>
         {categories.map(category => {
             return <div key={`category--${category.id}`} className="category">
                 <h3 className="category_label">{category.label}</h3>
+        <button className="category__button button is-small is-responsive is-danger" onClick={(evt) => categoryDelete(evt, category).then(() => {window.location.reload()})}>Delete</button>     
                 <div>
                 </div>
             </div>

--- a/src/managers/CategoryManager.js
+++ b/src/managers/CategoryManager.js
@@ -20,3 +20,14 @@ export const createCategory = (category) => {
         body: JSON.stringify(category)
     })
 }
+
+export const deleteCategory = (id) => {
+     return fetch(`http://localhost:8000/categories/${id}`, {
+         method: "DELETE",
+         headers:{
+             "Accept": "application/json",
+             "Content-Type": "application/json",
+             //"Authorization": `Token ${localStorage.getItem("lu_token")}`
+         }
+     })
+ }


### PR DESCRIPTION
## [Ticket](https://github.com/NSS-Day-Cohort-58/rare-rest-spacemonkey-mafia/issues/32)

## Description
Added a functioning delete button on the category list. Added the window pop up for confirmation and window reload function to return to categories automatcally. 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Test this branch:
  - Git fetch --all
  - Git checkout deletecategory-c
  - [ ] Test A - Test in REACT app by clicking delete next to the NEWS category.  You should be directed to the category list automatically and the list should not have NEWS any longer. 
  - [ ] Test B - N/A

## Checklist:
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
